### PR TITLE
Creata struttura  testing database

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ tmp
 .postman
 .github
 LICENSE
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data/
 *.out
 config.json
 tmp
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifeq ($(CI),)
 	PORT=$$(docker port $$ID | awk '{split($$0,a,":"); print a[2]}' ); \
 	sleep 5; \
 	go test -v -coverprofile=coverage.out -c . -o  build/testable . -- ; \
-	DB_URI="postgresql://postgres:postgres@localhost:$$PORT/postgres?sslmode=disable" ./build/testable -test.coverprofile=coverage.out -test.parallel=1 -- ; \
+	DB_URI="postgresql://postgres:postgres@localhost:$$PORT/postgres?sslmode=disable" ./build/testable -test.coverprofile=coverage.out  -- ; \
 	go tool cover -func=coverage.out -o=coverage.out ; \
 	docker kill $$ID
 else

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,14 @@ ifeq ($(CI),)
 	@ ID=$$(docker run -p 5432 -e POSTGRES_PASSWORD=postgres --rm -d postgres:14-alpine3.17); \
 	PORT=$$(docker port $$ID | awk '{split($$0,a,":"); print a[2]}' ); \
 	sleep 5; \
-	DB_URI=postgres://postgres:postgres@localhost:$$PORT/postgres?sslmode=disable go test -v -cover . ;\
+	go test -v -coverprofile=coverage.out -c . -o  build/testable . -- ; \
+	DB_URI="postgresql://postgres:postgres@localhost:$$PORT/postgres?sslmode=disable" ./build/testable -test.coverprofile=coverage.out -test.parallel=1 -- ; \
+	go tool cover -func=coverage.out -o=coverage.out ; \
 	docker kill $$ID
 else
 	$(info Running integration test on $(DB_URI))
 	go test -v -coverprofile=coverage.out -c . -o testable .
-	DB_URI=$(DB_URI) ./testable -test.coverprofile=coverage.out -test.v 
+	DB_URI=$(DB_URI) ./testable -test.coverprofile=coverage.out -test.v
 	go tool cover -func=coverage.out -o=coverage.out
 endif
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Game-Repository  
-![Coverage](https://img.shields.io/badge/Coverage-17.5%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-23.4%25-red)
 Implemented endpoint are:
 * /games:
     - GET /{id} retrieve a game by ID;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Game-Repository  
 ![Coverage](https://img.shields.io/badge/Coverage-23.4%25-red)
+<br>
 Implemented endpoint are:
 * /games:
     - GET /{id} retrieve a game by ID;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Game-Repository  
-![Coverage](https://img.shields.io/badge/Coverage-23.4%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-23.5%25-red)
 <br>
 Implemented endpoint are:
 * /games:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Game-Repository  
+
+
+
 Implemented endpoint are:
 * /games:
     - GET /{id} retrieve a game by ID;

--- a/controller.go
+++ b/controller.go
@@ -468,7 +468,7 @@ func (rc *RobotController) delete(w http.ResponseWriter, r *http.Request) error 
 		return err
 	}
 	if err := rc.service.DeleteByTestClass(testClassId.AsString()); err != nil {
-		return err
+		return makeApiError(err)
 	}
 	w.WriteHeader(http.StatusNoContent)
 	return nil

--- a/controller_test.go
+++ b/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -40,12 +41,15 @@ func (suite *GameControllerSuite) SetupSuite() {
 		On("Update",
 			mock.MatchedBy(func(id int64) bool { return id != 1 }),
 			&UpdateGameRequest{Name: "test", CurrentRound: 10}).
-		Return(nil, ErrNotFound)
+		Return(nil, ErrNotFound).
+		On("FindByInterval", mock.Anything, mock.Anything).
+		Return([]GameModel{}, int(64), nil)
 
 	controller := NewGameController(gr)
 
 	r := chi.NewMux()
 	r.Get("/{id}", makeHTTPHandlerFunc(controller.findByID))
+	r.Get("/", makeHTTPHandlerFunc(controller.list))
 	r.Post("/", makeHTTPHandlerFunc(controller.create))
 	r.Delete("/{id}", makeHTTPHandlerFunc(controller.delete))
 	r.Put("/{id}", makeHTTPHandlerFunc(controller.update))
@@ -61,17 +65,17 @@ func (suite *GameControllerSuite) TestFindByID() {
 		Arg            string
 	}{
 		{
-			Name:           "T01-GameNotExists",
+			Name:           "T00-01-GameNotExists",
 			ExpectedStatus: http.StatusNotFound,
 			Arg:            "12",
 		},
 		{
-			Name:           "T02-GameExists",
+			Name:           "T00-02-GameExists",
 			ExpectedStatus: http.StatusOK,
 			Arg:            "1",
 		},
 		{
-			Name:           "T03-BadID",
+			Name:           "T00-03-BadID",
 			ExpectedStatus: http.StatusBadRequest,
 			Arg:            "aaa",
 		},
@@ -82,7 +86,7 @@ func (suite *GameControllerSuite) TestFindByID() {
 			req, err := http.Get(fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Arg))
 			suite.NoError(err)
 
-			suite.Equal(tc.ExpectedStatus, req.StatusCode, err)
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
 
 		})
 	}
@@ -96,12 +100,12 @@ func (suite *GameControllerSuite) TestCreate() {
 		Body           string
 	}{
 		{
-			Name:           "T04-BadJson",
+			Name:           "T00-04-BadJson",
 			ExpectedStatus: http.StatusBadRequest,
 			Body:           `{"playersCount": 34`,
 		},
 		{
-			Name:           "T05-GameCreated",
+			Name:           "T00-05-GameCreated",
 			ExpectedStatus: http.StatusCreated,
 			Body:           `{"playersCount": 10}`,
 		},
@@ -114,7 +118,7 @@ func (suite *GameControllerSuite) TestCreate() {
 				bytes.NewBufferString(tc.Body))
 
 			suite.NoError(err)
-			suite.Equal(tc.ExpectedStatus, req.StatusCode, err)
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
 
 		})
 	}
@@ -129,17 +133,17 @@ func (suite *GameControllerSuite) TestDelete() {
 		Id             string
 	}{
 		{
-			Name:           "T06-BadId",
+			Name:           "T00-06-BadId",
 			ExpectedStatus: http.StatusBadRequest,
 			Id:             `26a4`,
 		},
 		{
-			Name:           "T07-GameDeleted",
+			Name:           "T00-07-GameDeleted",
 			ExpectedStatus: http.StatusNoContent,
 			Id:             `1`,
 		},
 		{
-			Name:           "T08-GameNotFound",
+			Name:           "T00-08-GameNotFound",
 			ExpectedStatus: http.StatusNotFound,
 			Id:             `14`,
 		},
@@ -154,7 +158,7 @@ func (suite *GameControllerSuite) TestDelete() {
 			res, err := http.DefaultClient.Do(req)
 			suite.NoError(err)
 
-			suite.Equal(tc.ExpectedStatus, res.StatusCode, err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
 
 		})
 	}
@@ -169,25 +173,25 @@ func (suite *GameControllerSuite) TestUpdate() {
 		Id             string
 	}{
 		{
-			Name:           "T09-BadId",
+			Name:           "T00-09-BadId",
 			ExpectedStatus: http.StatusBadRequest,
 			Body:           ` {"currentRound": 10, "name: "test"}`,
 			Id:             `1a`,
 		},
 		{
-			Name:           "T010-GameUpdated",
+			Name:           "T00-10-GameUpdated",
 			ExpectedStatus: http.StatusOK,
 			Body:           `{"currentRound": 10, "name": "test"}`,
 			Id:             `1`,
 		},
 		{
-			Name:           "T011-InvalidJSON",
+			Name:           "T00-11-InvalidJSON",
 			ExpectedStatus: http.StatusBadRequest,
 			Body:           ` {"currentRound": 10, "name: "test"}`,
 			Id:             `1`,
 		},
 		{
-			Name:           "T012-GameNotFound",
+			Name:           "T00-12-GameNotFound",
 			ExpectedStatus: http.StatusNotFound,
 			Body:           ` {"currentRound": 10, "name": "test"}`,
 			Id:             `11`,
@@ -204,12 +208,97 @@ func (suite *GameControllerSuite) TestUpdate() {
 			suite.NoError(err)
 			res, err := http.DefaultClient.Do(req)
 			suite.NoError(err)
-			suite.Equal(tc.ExpectedStatus, res.StatusCode, err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
 
 		})
 	}
 
 }
+func (suite *GameControllerSuite) TestList() {
+
+	type input struct {
+		Page      string
+		PageSize  string
+		StartDate string
+		EndDate   string
+	}
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Input          input
+	}{
+		{
+			Name:           "Valid input",
+			ExpectedStatus: http.StatusOK,
+			Input: input{
+				Page:      "1",
+				PageSize:  "10",
+				StartDate: "2023-01-01",
+				EndDate:   "2023-01-31",
+			},
+		},
+		{
+			Name:           "Invalid page",
+			ExpectedStatus: http.StatusBadRequest,
+			Input: input{
+				Page:      "invalid",
+				PageSize:  "10",
+				StartDate: "2023-01-01",
+				EndDate:   "2023-01-31",
+			},
+		},
+		{
+			Name:           "Invalid pageSize",
+			ExpectedStatus: http.StatusBadRequest,
+			Input: input{
+				Page:      "1",
+				PageSize:  "invalid",
+				StartDate: "2023-01-01",
+				EndDate:   "2023-01-31",
+			},
+		},
+		{
+			Name:           "Invalid startDate",
+			ExpectedStatus: http.StatusBadRequest,
+			Input: input{
+				Page:      "1",
+				PageSize:  "10",
+				StartDate: "invalid",
+				EndDate:   "2023-01-31",
+			},
+		},
+		{
+			Name:           "Invalid endDate",
+			ExpectedStatus: http.StatusBadRequest,
+			Input: input{
+				Page:      "1",
+				PageSize:  "10",
+				StartDate: "2023-01-01",
+				EndDate:   "invalid",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			q := url.Values{}
+			q.Set("page", tc.Input.Page)
+			q.Set("pageSize", tc.Input.PageSize)
+			q.Set("startDate", tc.Input.StartDate)
+			q.Set("endDate", tc.Input.EndDate)
+			url := fmt.Sprintf("%s?%s", suite.tServer.URL, q.Encode())
+			res, err := http.Get(url)
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+			defer res.Body.Close()
+		})
+	}
+
+}
+
 func TestGameControllerSuite(t *testing.T) {
 	suite.Run(t, new(GameControllerSuite))
 }
@@ -259,7 +348,322 @@ func (gr *MockedGameRepository) Update(id int64, ur *UpdateGameRequest) (*GameMo
 }
 
 func (gr *MockedGameRepository) FindByInterval(i *IntervalParams, p *PaginationParams) ([]GameModel, int64, error) {
-	return nil, 0, fmt.Errorf("not implemented")
+	args := gr.Called(i, p)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, int64(args.Int(1)), args.Error(2)
+	}
+	return v.([]GameModel), int64(args.Int(1)), args.Error(2)
+
+}
+
+type RoundControllerSuite struct {
+	suite.Suite
+	tServer *httptest.Server
+}
+
+func (suite *RoundControllerSuite) SetupSuite() {
+	rr := new(MockedRoundRepository)
+	rr.
+		On("Create", &CreateRoundRequest{GameId: 1, TestClassId: "a.java", Order: 1}).
+		Return(&RoundModel{ID: 1}, nil).
+		On("Create",
+			mock.MatchedBy(func(r *CreateRoundRequest) bool { return r.GameId != 1 })).
+		Return(nil, ErrNotFound).
+		On("FindById", int64(1)).
+		Return(&RoundModel{ID: 1}, nil).
+		On("FindById",
+			mock.MatchedBy(func(id int64) bool { return id != 1 })).
+		Return(nil, ErrNotFound).
+		On("Delete", int64(1)).
+		Return(nil).
+		On("Delete",
+			mock.MatchedBy(func(id int64) bool { return id != 1 })).
+		Return(ErrNotFound).
+		On("Update", int64(1),
+			&UpdateRoundRequest{Order: 2}).
+		Return(&RoundModel{}, nil).
+		On("Update",
+			mock.MatchedBy(func(id int64) bool { return id != 1 }),
+			&UpdateRoundRequest{Order: 2}).
+		Return(nil, ErrNotFound).
+		On("FindByGame", int64(1)).
+		Return([]RoundModel{}, nil).
+		On("FindByGame", mock.MatchedBy(func(id int64) bool { return id != 1 })).
+		Return(nil, ErrNotFound)
+
+	controller := NewRoundController(rr)
+
+	r := chi.NewMux()
+	r.Get("/{id}", makeHTTPHandlerFunc(controller.findByID))
+	r.Get("/", makeHTTPHandlerFunc(controller.list))
+	r.Post("/", makeHTTPHandlerFunc(controller.create))
+	r.Delete("/{id}", makeHTTPHandlerFunc(controller.delete))
+	r.Put("/{id}", makeHTTPHandlerFunc(controller.update))
+
+	suite.tServer = httptest.NewServer(r)
+}
+
+func (suite *RoundControllerSuite) TestFindByID() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Arg            string
+	}{
+		{
+			Name:           "T01-01-RoundNotExists",
+			ExpectedStatus: http.StatusNotFound,
+			Arg:            "12",
+		},
+		{
+			Name:           "T01-02-RoundExists",
+			ExpectedStatus: http.StatusOK,
+			Arg:            "1",
+		},
+		{
+			Name:           "T01-03-BadID",
+			ExpectedStatus: http.StatusBadRequest,
+			Arg:            "aaa",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			req, err := http.Get(fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Arg))
+			suite.NoError(err)
+
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
+
+		})
+	}
+}
+
+func (suite *RoundControllerSuite) TestCreate() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Body           string
+	}{
+		{
+			Name:           "T01-04-BadJson",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           `{"playersCount": 34`,
+		},
+		{
+			Name:           "T01-05-RoundCreated",
+			ExpectedStatus: http.StatusCreated,
+			Body:           `{"gameId": 1, "testClassId": "a.java", "order": 1}`,
+		},
+		{
+			Name:           "T01-06-GameNotExists",
+			ExpectedStatus: http.StatusNotFound,
+			Body:           `{"gameId": 2}`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			req, err := http.Post(suite.tServer.URL,
+				"application/json",
+				bytes.NewBufferString(tc.Body))
+
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+
+func (suite *RoundControllerSuite) TestDelete() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Id             string
+	}{
+		{
+			Name:           "T01-07-BadId",
+			ExpectedStatus: http.StatusBadRequest,
+			Id:             `26a4`,
+		},
+		{
+			Name:           "T01-08-RoundDeleted",
+			ExpectedStatus: http.StatusNoContent,
+			Id:             `1`,
+		},
+		{
+			Name:           "T01-09-RoundNotFound",
+			ExpectedStatus: http.StatusNotFound,
+			Id:             `14`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			url := fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Id)
+			req, err := http.NewRequest(http.MethodDelete, url, nil)
+			suite.NoError(err)
+
+			res, err := http.DefaultClient.Do(req)
+			suite.NoError(err)
+
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+func (suite *RoundControllerSuite) TestUpdate() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Body           string
+		Id             string
+	}{
+		{
+			Name:           "T01-10-BadId",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           ` {"order": 1}`,
+			Id:             `1a`,
+		},
+		{
+			Name:           "T01-11-RoundUpdated",
+			ExpectedStatus: http.StatusOK,
+			Body:           `{"order": 2}`,
+			Id:             `1`,
+		},
+		{
+			Name:           "T01-12-InvalidJSON",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           ` {"order": 1t"}`,
+			Id:             `1`,
+		},
+		{
+			Name:           "T01-13-RoundNotFound",
+			ExpectedStatus: http.StatusNotFound,
+			Body:           ` {"order": 2}`,
+			Id:             `11`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			url := fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Id)
+			req, err := http.NewRequest(http.MethodPut,
+				url,
+				bytes.NewBufferString(tc.Body))
+
+			suite.NoError(err)
+			res, err := http.DefaultClient.Do(req)
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+func (suite *RoundControllerSuite) TestList() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Input          string
+	}{
+		{
+			Name:           "T01-14-OkList",
+			ExpectedStatus: http.StatusOK,
+			Input:          "1",
+		},
+		{
+			Name:           "T01-15-InvalidId",
+			ExpectedStatus: http.StatusBadRequest,
+			Input:          "invalid",
+		},
+		{
+			Name:           "T01-16-RoundNotFound",
+			ExpectedStatus: http.StatusNotFound,
+			Input:          "2",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			q := url.Values{}
+			q.Add("gameId", tc.Input)
+			url := fmt.Sprintf("%s?%s", suite.tServer.URL, q.Encode())
+			res, err := http.Get(url)
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+			defer res.Body.Close()
+		})
+	}
+
+}
+
+func TestRoundControllerSuite(t *testing.T) {
+	suite.Run(t, new(RoundControllerSuite))
+}
+
+func (suite *RoundControllerSuite) TearDownSuite() {
+	defer suite.tServer.Close()
+}
+
+type MockedRoundRepository struct {
+	mock.Mock
+}
+
+func (gr *MockedRoundRepository) Create(r *CreateRoundRequest) (*RoundModel, error) {
+	args := gr.Called(r)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.(*RoundModel), args.Error(1)
+}
+
+func (gr *MockedRoundRepository) FindById(id int64) (*RoundModel, error) {
+	args := gr.Called(id)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.(*RoundModel), args.Error(1)
+
+}
+
+func (gr *MockedRoundRepository) Delete(id int64) error {
+	args := gr.Called(id)
+	return args.Error(0)
+}
+
+func (gr *MockedRoundRepository) Update(id int64, ur *UpdateRoundRequest) (*RoundModel, error) {
+	args := gr.Called(id, ur)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.(*RoundModel), args.Error(1)
+}
+
+func (gr *MockedRoundRepository) FindByGame(id int64) ([]RoundModel, error) {
+	args := gr.Called(id)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.([]RoundModel), args.Error(1)
+
 }
 
 type TurnControllerSuite struct {
@@ -289,7 +693,30 @@ func (suite *TurnControllerSuite) SetupSuite() {
 		On("SaveFile",
 			mock.MatchedBy(func(id int64) bool { return id != 1 }),
 			mock.Anything).
-		Return(ErrNotFound)
+		Return(ErrNotFound).
+		On("CreateBulk", &CreateTurnsRequest{RoundId: 1}).
+		Return([]TurnModel{}, nil).
+		On("CreateBulk", mock.MatchedBy(func(r *CreateTurnsRequest) bool { return r.RoundId != 1 })).
+		Return(nil, ErrNotFound).
+		On("FindById", int64(1)).
+		Return(&TurnModel{ID: 1}, nil).
+		On("FindById",
+			mock.MatchedBy(func(id int64) bool { return id != 1 })).
+		Return(nil, ErrNotFound).
+		On("Delete", int64(1)).
+		Return(nil).
+		On("Delete",
+			mock.MatchedBy(func(id int64) bool { return id != 1 })).
+		Return(ErrNotFound).
+		On("Update", int64(1), &UpdateTurnRequest{IsWinner: true, Scores: "a"}).
+		Return(&TurnModel{}, nil).
+		On("Update", mock.MatchedBy(func(id int64) bool { return id != 1 }),
+			&UpdateTurnRequest{IsWinner: true, Scores: "a"}).
+		Return(nil, ErrNotFound).
+		On("FindByRound", int64(1)).
+		Return([]TurnModel{}, nil).
+		On("FindByRound", mock.MatchedBy(func(id int64) bool { return id != 1 })).
+		Return(nil, ErrNotFound)
 
 	suite.tmpDir = os.TempDir()
 	controller := NewTurnController(tr)
@@ -298,8 +725,215 @@ func (suite *TurnControllerSuite) SetupSuite() {
 
 	r.Get("/{id}/files", makeHTTPHandlerFunc(controller.download))
 	r.Put("/{id}/files", makeHTTPHandlerFunc(controller.upload))
+	r.Post("/", makeHTTPHandlerFunc(controller.create))
+	r.Get("/", makeHTTPHandlerFunc(controller.list))
+	r.Put("/{id}", makeHTTPHandlerFunc(controller.update))
+	r.Delete("/{id}", makeHTTPHandlerFunc(controller.delete))
+	r.Get("/{id}", makeHTTPHandlerFunc(controller.findByID))
 
 	suite.tServer = httptest.NewServer(r)
+}
+
+func (suite *TurnControllerSuite) TestFindByID() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Arg            string
+	}{
+		{
+			Name:           "T02-01-TurnNotExists",
+			ExpectedStatus: http.StatusNotFound,
+			Arg:            "12",
+		},
+		{
+			Name:           "T02-02-TurnExists",
+			ExpectedStatus: http.StatusOK,
+			Arg:            "1",
+		},
+		{
+			Name:           "T02-03-BadID",
+			ExpectedStatus: http.StatusBadRequest,
+			Arg:            "aaa",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			req, err := http.Get(fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Arg))
+			suite.NoError(err)
+
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
+
+		})
+	}
+}
+
+func (suite *TurnControllerSuite) TestCreate() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Body           string
+	}{
+		{
+			Name:           "T02-04-BadJson",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           `{"roundId": 34`,
+		},
+		{
+			Name:           "T02-05-TurnCreated",
+			ExpectedStatus: http.StatusCreated,
+			Body:           `{"roundId": 1, "playerId": 1}`,
+		},
+		{
+			Name:           "T02-06-RoundNotExists",
+			ExpectedStatus: http.StatusNotFound,
+			Body:           `{"turnId": 2}`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			req, err := http.Post(suite.tServer.URL,
+				"application/json",
+				bytes.NewBufferString(tc.Body))
+
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+
+func (suite *TurnControllerSuite) TestDelete() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Id             string
+	}{
+		{
+			Name:           "T02-07-BadId",
+			ExpectedStatus: http.StatusBadRequest,
+			Id:             `26a4`,
+		},
+		{
+			Name:           "T02-08-TurnDeleted",
+			ExpectedStatus: http.StatusNoContent,
+			Id:             `1`,
+		},
+		{
+			Name:           "T02-09-TurnNotFound",
+			ExpectedStatus: http.StatusNotFound,
+			Id:             `14`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			url := fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Id)
+			req, err := http.NewRequest(http.MethodDelete, url, nil)
+			suite.NoError(err)
+
+			res, err := http.DefaultClient.Do(req)
+			suite.NoError(err)
+
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+func (suite *TurnControllerSuite) TestUpdate() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Body           string
+		Id             string
+	}{
+		{
+			Name:           "T02-10-BadId",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           `{"scores": "a", "isWinner": true}`,
+			Id:             `1a`,
+		},
+		{
+			Name:           "T02-11-TurnUpdated",
+			ExpectedStatus: http.StatusOK,
+			Body:           `{"scores": "a", "isWinner": true}`,
+			Id:             `1`,
+		},
+		{
+			Name:           "T02-12-InvalidJSON",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           `{"order"}`,
+			Id:             `1`,
+		},
+		{
+			Name:           "T02-13-TurnNotFound",
+			ExpectedStatus: http.StatusNotFound,
+			Body:           `{"scores": "a", "isWinner": true}`,
+			Id:             `11`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			url := fmt.Sprintf("%s/%s", suite.tServer.URL, tc.Id)
+			req, err := http.NewRequest(http.MethodPut,
+				url,
+				bytes.NewBufferString(tc.Body))
+
+			suite.NoError(err)
+			res, err := http.DefaultClient.Do(req)
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+func (suite *TurnControllerSuite) TestList() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Input          string
+	}{
+		{
+			Name:           "T02-14-TurnsFound",
+			ExpectedStatus: http.StatusOK,
+			Input:          "1",
+		},
+		{
+			Name:           "T02-15-ErrBadId",
+			ExpectedStatus: http.StatusBadRequest,
+			Input:          "invalid",
+		},
+		{
+			Name:           "T02-16-RoundNotFound",
+			ExpectedStatus: http.StatusNotFound,
+			Input:          "2",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			q := url.Values{}
+			q.Add("roundId", tc.Input)
+			url := fmt.Sprintf("%s?%s", suite.tServer.URL, q.Encode())
+			res, err := http.Get(url)
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+			defer res.Body.Close()
+		})
+	}
+
 }
 
 func (suite *TurnControllerSuite) TestUpload() {
@@ -385,7 +1019,7 @@ func (suite *TurnControllerSuite) TestDownload() {
 			_, err = io.Copy(io.Discard, res.Body)
 
 			suite.NoError(err)
-			suite.Equal(tc.ExpectedStatus, res.StatusCode, err)
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
 
 		})
 	}
@@ -404,8 +1038,15 @@ type MockedTurnRepository struct {
 }
 
 func (m *MockedTurnRepository) CreateBulk(request *CreateTurnsRequest) ([]TurnModel, error) {
-	return nil, fmt.Errorf("not implemented")
+	args := m.Called(request)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.([]TurnModel), args.Error(1)
 }
+
 func (m *MockedTurnRepository) FindById(id int64) (*TurnModel, error) {
 	args := m.Called(id)
 	v := args.Get(0)
@@ -417,14 +1058,28 @@ func (m *MockedTurnRepository) FindById(id int64) (*TurnModel, error) {
 }
 
 func (m *MockedTurnRepository) Delete(id int64) error {
-	return fmt.Errorf("not implemented")
+	args := m.Called(id)
+	return args.Error(0)
 }
 
 func (m *MockedTurnRepository) FindByRound(id int64) ([]TurnModel, error) {
-	return nil, fmt.Errorf("not implemented")
+	args := m.Called(id)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.([]TurnModel), args.Error(1)
 }
+
 func (m *MockedTurnRepository) Update(id int64, request *UpdateTurnRequest) (*TurnModel, error) {
-	return nil, fmt.Errorf("not implemented")
+	args := m.Called(id, request)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.(*TurnModel), args.Error(1)
 }
 
 func (m *MockedTurnRepository) SaveFile(id int64, r io.Reader) error {
@@ -440,4 +1095,198 @@ func (m *MockedTurnRepository) GetFile(id int64) (string, *os.File, error) {
 		return "", nil, args.Error(2)
 	}
 	return args.String(0), v.(*os.File), args.Error(2)
+}
+
+type RobotControllerSuite struct {
+	suite.Suite
+	tServer *httptest.Server
+}
+
+func (suite *RobotControllerSuite) SetupSuite() {
+	tr := new(MockedRobotRepository)
+
+	tr.
+		On("CreateBulk", mock.Anything).
+		Return(1, nil).
+		On("FindByFilter", mock.Anything, mock.Anything, mock.Anything).
+		Return(&RobotModel{ID: 1}, nil).
+		On("DeleteByTestClass", "a.java").
+		Return(nil).
+		On("DeleteByTestClass",
+			mock.MatchedBy(func(id string) bool { return id != "a.java" })).
+		Return(ErrNotFound)
+
+	controller := NewRobotController(tr)
+
+	r := chi.NewMux()
+
+	r.Post("/", makeHTTPHandlerFunc(controller.createBulk))
+	r.Get("/", makeHTTPHandlerFunc(controller.findByFilter))
+	r.Delete("/", makeHTTPHandlerFunc(controller.delete))
+
+	suite.tServer = httptest.NewServer(r)
+}
+func (suite *RobotControllerSuite) TearDownSuite() {
+	defer suite.tServer.Close()
+}
+func TestRobotControllerSuite(t *testing.T) {
+	suite.Run(t, new(RobotControllerSuite))
+}
+
+func (suite *RobotControllerSuite) TestFindByFilter() {
+	type input struct {
+		TestClassId string
+		Difficulty  string
+		RobotType   string
+	}
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Input          input
+	}{
+		{
+			Name:           "T04-01-ValidInput",
+			ExpectedStatus: http.StatusOK,
+			Input: input{
+				TestClassId: "TestRobot.java",
+				Difficulty:  "easy",
+				RobotType:   "0",
+			},
+		},
+		{
+			Name:           "T04-02-ValidInput",
+			ExpectedStatus: http.StatusOK,
+			Input: input{
+				TestClassId: "SomeOtherRobot.java",
+				Difficulty:  "medium",
+				RobotType:   "1",
+			},
+		},
+		{
+			Name:           "T04-03-InvalidInput",
+			ExpectedStatus: http.StatusBadRequest,
+			Input: input{
+				TestClassId: "InvalidRobot.java",
+				Difficulty:  "hard",
+				RobotType:   "2",
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			q := url.Values{}
+			q.Set("testClassId", tc.Input.TestClassId)
+			q.Set("difficulty", tc.Input.Difficulty)
+			q.Set("type", tc.Input.RobotType)
+
+			req, err := http.Get(fmt.Sprintf("%s?%s", suite.tServer.URL, q.Encode()))
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
+
+		})
+	}
+}
+func (suite *RobotControllerSuite) TestCreate() {
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		Body           string
+	}{
+		{
+			Name:           "T04-04-ValidInput",
+			ExpectedStatus: http.StatusCreated,
+			Body:           `{"robots": [{"testClassId": "a.java", "scores": "some scores", "difficulty": "some difficulty", "type": 0}]}`,
+		},
+		{
+			Name:           "T04-05-InvalidRobotType",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           `{"robots": [{"testClassId": "a.java", "scores": "some scores", "difficulty": "some difficulty", "type": 2}]}`,
+		},
+		{
+			Name:           "T04-06-MissingField",
+			ExpectedStatus: http.StatusCreated,
+			Body:           `{"robots": [{"testClassId": "a.java", "scores": "some scores", "difficulty": "some difficulty"}]}`,
+		},
+		{
+			Name:           "T04-07-BadlyFormattedJSON",
+			ExpectedStatus: http.StatusBadRequest,
+			Body:           `{"robots: [{"testClassId": "a.java", "scores": "some scores", "difficulty": "some difficulty", "type": 1}]}`,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			req, err := http.Post(suite.tServer.URL,
+				"application/json",
+				bytes.NewBufferString(tc.Body))
+
+			suite.NoError(err)
+			suite.Equal(tc.ExpectedStatus, req.StatusCode, tc.Name)
+
+		})
+	}
+}
+
+func (suite *RobotControllerSuite) TestDelete() {
+
+	tcs := []struct {
+		Name           string
+		ExpectedStatus int
+		TestClassId    string
+	}{
+		{
+			Name:           "T04-08-Ok",
+			ExpectedStatus: http.StatusNoContent,
+			TestClassId:    `a.java`,
+		},
+		{
+			Name:           "T04-09-NotFound",
+			ExpectedStatus: http.StatusNotFound,
+			TestClassId:    `b.java`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			p := url.Values{}
+			p.Add("testClassId", tc.TestClassId)
+			url := fmt.Sprintf("%s?%s", suite.tServer.URL, p.Encode())
+			req, err := http.NewRequest(http.MethodDelete, url, nil)
+			suite.NoError(err)
+
+			res, err := http.DefaultClient.Do(req)
+			suite.NoError(err)
+
+			suite.Equal(tc.ExpectedStatus, res.StatusCode, tc.Name)
+
+		})
+	}
+
+}
+
+type MockedRobotRepository struct {
+	mock.Mock
+}
+
+func (m *MockedRobotRepository) CreateBulk(request *CreateRobotsRequest) (int, error) {
+	args := m.Called(request)
+
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockedRobotRepository) FindByFilter(testClassId string, difficulty string, t RobotType) (*RobotModel, error) {
+	args := m.Called(testClassId, difficulty, t)
+	v := args.Get(0)
+
+	if v == nil {
+		return nil, args.Error(1)
+	}
+	return v.(*RobotModel), args.Error(1)
+
+}
+func (m *MockedRobotRepository) DeleteByTestClass(testClassId string) error {
+	args := m.Called(testClassId)
+	return args.Error(0)
 }

--- a/dto.go
+++ b/dto.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -52,15 +53,25 @@ type CreateRobotRequest struct {
 	Type        RobotType `json:"type"`
 }
 
-func (CreateRobotRequest) Validate() error {
-	return nil
+func (r CreateRobotRequest) Validate() error {
+	switch r.Type {
+	case randoop, evosuite:
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported robot type %q", ErrInvalidParam, r.Type)
+	}
 }
 
 type CreateRobotsRequest struct {
 	Robots []CreateRobotRequest `json:"robots"`
 }
 
-func (CreateRobotsRequest) Validate() error {
+func (robots CreateRobotsRequest) Validate() error {
+	for _, robot := range robots.Robots {
+		if err := robot.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -145,22 +156,6 @@ func (s CustomString) AsString() string {
 }
 
 func (CustomString) Validate() error {
-	return nil
-}
-
-// CustomInt8 is a dummy type that implements  Convertable and Validable interfaces
-type CustomInt8 int8
-
-func (CustomInt8) Convert(s string) (CustomInt8, error) {
-	a, err := strconv.ParseInt(s, 10, 8)
-	return CustomInt8(a), err
-}
-
-func (k CustomInt8) AsInt8() int8 {
-	return int8(k)
-}
-
-func (CustomInt8) Validate() error {
 	return nil
 }
 

--- a/model.go
+++ b/model.go
@@ -192,6 +192,9 @@ func (data *RobotType) Scan(value interface{}) error {
 }
 
 func (RobotType) Convert(s string) (RobotType, error) {
+	if s == "" {
+		return randoop, fmt.Errorf("%w: missing robot type", ErrInvalidParam)
+	}
 	n, err := strconv.ParseInt(s, 10, 8)
 	if err != nil {
 		return RobotType(0), err

--- a/service.go
+++ b/service.go
@@ -386,6 +386,9 @@ func (tr *TurnStorage) Delete(id int64) error {
 }
 
 func (ts *TurnStorage) SaveFile(id int64, r io.Reader) error {
+	if r == nil {
+		return fmt.Errorf("%w: body is empty", ErrInvalidParam)
+	}
 	err := ts.db.Transaction(func(tx *gorm.DB) error {
 		var (
 			err   error

--- a/service.go
+++ b/service.go
@@ -466,7 +466,9 @@ func (ts *TurnStorage) GetFile(id int64) (string, *os.File, error) {
 
 	f, err := os.Open(metadata.Path)
 
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil, ErrNotFound
+	} else if err != nil {
 		return "", nil, err
 	}
 

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"database/sql"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/logger"
+)
+
+type TurnRepositorySuite struct {
+	suite.Suite
+	db       *gorm.DB
+	testPath string
+	service  TurnStorage
+}
+
+func (suite *TurnRepositorySuite) SetupSuite() {
+	dbUrl := os.Getenv("DB_URI")
+	db, err := gorm.Open(postgres.Open(dbUrl), &gorm.Config{
+		SkipDefaultTransaction: true,
+		TranslateError:         true,
+		Logger:                 logger.Discard,
+	})
+
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+
+	suite.db = db
+
+	err = db.AutoMigrate(
+		&GameModel{},
+		&RoundModel{},
+		&PlayerModel{},
+		&TurnModel{},
+		&MetadataModel{},
+	)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+
+	suite.testPath = path.Join(os.TempDir(), "testdata")
+	if err := os.Mkdir(suite.testPath, os.ModePerm); err != nil && !errors.Is(err, os.ErrExist) {
+		suite.T().Fatal(err)
+	}
+
+	suite.service = *NewTurnRepository(db, suite.testPath)
+}
+
+func (suite *TurnRepositorySuite) Cleanup() {
+	// Truncate each table individually
+	if err := suite.db.Exec("TRUNCATE TABLE turns RESTART IDENTITY CASCADE").Error; err != nil {
+		suite.T().Fatal(err)
+	}
+	if err := suite.db.Exec("TRUNCATE TABLE metadata RESTART IDENTITY CASCADE").Error; err != nil {
+		suite.T().Fatal(err)
+	}
+	if err := suite.db.Exec("TRUNCATE TABLE rounds RESTART IDENTITY CASCADE").Error; err != nil {
+		suite.T().Fatal(err)
+	}
+	if err := suite.db.Exec("TRUNCATE TABLE players RESTART IDENTITY CASCADE").Error; err != nil {
+		suite.T().Fatal(err)
+	}
+	if err := suite.db.Exec("TRUNCATE TABLE games RESTART IDENTITY CASCADE").Error; err != nil {
+		suite.T().Fatal(err)
+	}
+
+}
+
+func (suite *TurnRepositorySuite) SeedTestData() {
+	// Create a game with rounds and turns
+
+	// Create a test game
+	game := GameModel{
+		Name:         "Test Game",
+		PlayersCount: 4,
+		Rounds: []RoundModel{
+			{
+				Order:       1,
+				TestClassId: "test",
+				Turns: []TurnModel{
+					{
+						PlayerID: 1,          // Replace with your desired player ID
+						Scores:   "10,20,30", // Replace with your desired scores
+					},
+					// Add more turns as needed
+				},
+			},
+			// Add more rounds as needed
+		},
+	}
+
+	// Create a player
+	player := PlayerModel{
+		AccountID: "testplayer", // Replace with your desired account ID
+	}
+
+	// Create test metadata
+	metadata := MetadataModel{
+		Path: path.Join(suite.testPath, "1.zip"), // Replace with your desired path
+	}
+
+	// Create a player-game relationship
+	playerGame := PlayerGameModel{
+		PlayerID: 1, // Replace with the player ID
+		GameID:   1, // Replace with the game ID
+	}
+
+	// Save the test data to the database
+	err := suite.db.Transaction(func(tx *gorm.DB) error {
+
+		// Create the player
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&player).Error; err != nil {
+			return err
+		}
+		// Create the game
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&game).Error; err != nil {
+			return err
+		}
+		metadata.TurnID = sql.NullInt64{Valid: true, Int64: 1}
+		// Create the metadata
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&metadata).Error; err != nil {
+			return err
+		}
+		// Create the player-game relationship
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&playerGame).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// Check for errors during data seeding
+	if err != nil {
+		suite.T().Fatalf("Failed to seed test data: %v", err)
+	}
+
+	// Create test file
+	f, err := os.Create(metadata.Path)
+	if err != nil {
+		suite.T().Fatalf("Failed to create %s: %v", metadata.Path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte("some file content")); err != nil {
+		suite.T().Fatal(err)
+	}
+}
+
+func (suite *TurnRepositorySuite) TestSaveFile() {
+	type input struct {
+		turnId  int64
+		content io.Reader
+	}
+
+	type output struct {
+		err error
+	}
+
+	tcs := []struct {
+		Name   string
+		Output output
+		Input  input
+	}{
+		{
+			Name:   "T51-NotAZip",
+			Output: output{err: ErrNotAZip},
+			Input: input{
+				turnId:  1,
+				content: bytes.NewBufferString("hello"),
+			},
+		},
+		{
+			Name:   "T52-SuccessfulSave",
+			Output: output{err: nil},
+			Input: input{
+				turnId:  1,
+				content: generateValidZipContent(suite.T(), []byte("hello")),
+			},
+		},
+		{
+			Name:   "T53-EmptyFile",
+			Output: output{err: nil},
+			Input: input{
+				turnId:  1,
+				content: generateValidZipContent(suite.T(), []byte(nil)),
+			},
+		},
+		{
+			Name:   "T54-InvalidTurnID",
+			Output: output{err: ErrNotFound},
+			Input: input{
+				turnId:  -1,
+				content: generateValidZipContent(suite.T(), []byte("hello")),
+			},
+		},
+		{
+			Name:   "T55-NullBody",
+			Output: output{err: ErrInvalidParam},
+			Input: input{
+				turnId:  1,
+				content: nil,
+			},
+		},
+		{
+			Name:   "T56-Turn not found",
+			Output: output{err: ErrNotFound},
+			Input: input{
+				turnId:  1000,
+				content: generateValidZipContent(suite.T(), []byte("hello")),
+			},
+		},
+	}
+	service := NewTurnRepository(suite.db, suite.testPath)
+
+	for _, tc := range tcs {
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			suite.SeedTestData()
+			defer suite.Cleanup()
+			err := service.SaveFile(tc.Input.turnId, tc.Input.content)
+			suite.Equalf(
+				suite.ErrorIs(err, tc.Output.err), true,
+				"exptected %v; got %v", tc.Output.err, err)
+		})
+
+	}
+
+}
+
+func (s *TurnRepositorySuite) TeardownSuite() {
+	os.RemoveAll(s.testPath)
+}
+
+func (suite *TurnRepositorySuite) TestGetFile() {
+	type input struct {
+		turnId int64
+	}
+
+	type output struct {
+		fname string
+		file  *os.File
+		err   error
+	}
+
+	tcs := []struct {
+		Name   string
+		Output output
+		Input  input
+	}{
+		{
+			Name:   "T58-TurnNotFound",
+			Output: output{fname: "", file: nil, err: ErrNotFound},
+			Input: input{
+				turnId: 100,
+			},
+		},
+		{
+			Name:   "T59-BadMetadata",
+			Output: output{fname: "", file: nil, err: ErrNotFound},
+			Input: input{
+				turnId: 2,
+			},
+		},
+		{
+			Name:   "T510-OkFile",
+			Output: output{"1.zip", &os.File{}, nil},
+			Input: input{
+				turnId: 1,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		suite.T().Run(tc.Name, func(t *testing.T) {
+			suite.SeedTestData()
+			defer suite.Cleanup()
+			_, f, err := suite.service.GetFile(tc.Input.turnId)
+			defer f.Close()
+			suite.Equalf(
+				suite.ErrorIs(err, tc.Output.err),
+				true,
+				"%s - exptected %v; got %v", tc.Name, tc.Output.err, err,
+			)
+		})
+
+	}
+
+}
+
+func TestServiceSuite(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_INTEGRATION"); ok {
+		t.Skip()
+	}
+	suite.Run(t, new(TurnRepositorySuite))
+}
+
+func generateValidZipContent(t *testing.T, content []byte) io.Reader {
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+
+	// Create a file inside the zip archive
+	fileWriter, err := zipWriter.Create("file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write some content to the file
+	_, err = fileWriter.Write([]byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the zip writer
+	err = zipWriter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return buf
+}


### PR DESCRIPTION
Un target "test-integration" è stato creato nel Makefile che prende in ingresso un flag CI:

1. CI non settato: viene creato un Docker container con un'istanza Postgres con una porta randomica dell'host. L'indirizzo  del database , generato dinamicamente, viene iniettato come variabile d'ambiente `DB_URI` nel programma di testing. In questo caso, il comando per eseguire il test in locale sarebbe `make test-integration`;
2. CI settato: il sistema non esegue nessun database locale, ma si aspetta di ricevere dall'esterno la variabile `DB_URI`. Questo approccio è utile anche quando si vuole effettuare il test usando un'istanza di database _custom_. Ad esempio, il testing con database può essere eseguito con `make test-integration CI=1 DB_URI=<DB_URI>`;

Inoltre, è stato modificato il file di CI per avere un badge per la percentuale di righe di codice coperte.

Infine, è stato aggiunto il file `service_test.go` con dei casi di test per le funzionalità  `SaveFile()` e `GetFile()`.